### PR TITLE
changed inflation amount for 8 hours

### DIFF
--- a/federation/blocksigning.py
+++ b/federation/blocksigning.py
@@ -27,7 +27,7 @@ class BlockSigning(DaemonThread):
 
         self.inflation = None
         if in_rate > 0:
-            self.inflation = Inflation(self.total, self.my_id, self.ocean,
+            self.inflation = Inflation(self.total, self.my_id, self.ocean, self.interval
                 in_rate, in_period, in_address, script, conf["reissuanceprivkey"])
 
     def run(self):

--- a/federation/federation.py
+++ b/federation/federation.py
@@ -35,7 +35,7 @@ def parse_args():
     parser.add_argument('--nodes', default="", type=str, help="Nodes for zmq protocol. Example use 'node0:1503,node1:1502'")
 
     parser.add_argument('--inflationrate', default=IN_RATE, type=float, help="Inflation rate. Example 0.0101010101")
-    parser.add_argument('--inflationperiod', default=IN_PERIOD, type=int, help="Inflation period (in minutes)")
+    parser.add_argument('--inflationperiod', default=IN_PERIOD, type=int, help="Inflation period (in blocks)")
     parser.add_argument('--inflationaddress', default=IN_ADDRESS, type=str, help="Address for inflation payments")
     parser.add_argument('--reissuancescript', default=SCRIPT, type=str, help="Reissuance token script")
     parser.add_argument('--reissuanceprivkey', default=PRVKEY, type=str, help="Reissuance private key")

--- a/federation/inflation.py
+++ b/federation/inflation.py
@@ -2,11 +2,14 @@
 import logging
 import sys
 
+YEAR = 60*60*24*365
+
 class Inflation():
-    def __init__(self, total, my_id, ocean, in_rate, in_period, in_address, script, key):
+    def __init__(self, total, my_id, ocean, interval, in_rate, in_period, in_address, script, key):
         self.logger = logging.getLogger(self.__class__.__name__)
         self.total = total
         self.my_id = my_id
+        self.interval = interval
         self.rate = in_rate
         self.period = in_period
         self.address = in_address
@@ -142,7 +145,7 @@ class Inflation():
                                 entropy = entry["entropy"]
                                 break
                         #the spendable amount needs to be inflated over a period of 1 hour
-                        total_reissue = amount_spendable*(1.0+float(self.rate))**(8.0/(24*365))-amount_spendable
+                        total_reissue = amount_spendable*(1.0+float(self.rate))**(self.interval*self.period/YEAR)-amount_spendable
                         #check to see if there are any assets unfrozenx in the last interval
                         amount_unfrozen = 0.0
                         for frzout in frzhist:
@@ -152,7 +155,7 @@ class Inflation():
                                     elapsed_interval = backdate // self.period
                                     self.logger.info("elapsed_interval: "+str(elapsed_interval))
                                     amount_unfrozen = float(frzout["value"])
-                                    total_reissue += amount_unfrozen*(1.0+float(self.rate))**(elapsed_interval*8/(24*365))-amount_unfrozen
+                                    total_reissue += amount_unfrozen*(1.0+float(self.rate))**(elapsed_interval*self.interval*self.period/YEAR)-amount_unfrozen
                                     self.logger.info("backdate reissue: "+ str(total_reissue))
                         self.logger.info("Reissue asset "+asset+" by "+str(round(total_reissue,8)))
                         if total_reissue == 0.0:

--- a/federation/inflation.py
+++ b/federation/inflation.py
@@ -142,7 +142,7 @@ class Inflation():
                                 entropy = entry["entropy"]
                                 break
                         #the spendable amount needs to be inflated over a period of 1 hour
-                        total_reissue = amount_spendable*(1.0+float(self.rate))**(1.0/(24*365))-amount_spendable
+                        total_reissue = amount_spendable*(1.0+float(self.rate))**(8.0/(24*365))-amount_spendable
                         #check to see if there are any assets unfrozenx in the last interval
                         amount_unfrozen = 0.0
                         for frzout in frzhist:
@@ -152,7 +152,7 @@ class Inflation():
                                     elapsed_interval = backdate // self.period
                                     self.logger.info("elapsed_interval: "+str(elapsed_interval))
                                     amount_unfrozen = float(frzout["value"])
-                                    total_reissue += amount_unfrozen*(1.0+float(self.rate))**(elapsed_interval/(24*365))-amount_unfrozen
+                                    total_reissue += amount_unfrozen*(1.0+float(self.rate))**(elapsed_interval*8/(24*365))-amount_unfrozen
                                     self.logger.info("backdate reissue: "+ str(total_reissue))
                         self.logger.info("Reissue asset "+asset+" by "+str(round(total_reissue,8)))
                         if total_reissue == 0.0:


### PR DESCRIPTION
8 hour inflation period. The config needs to be updated also (480 block/mins). 

Ideally, the inflation should be provided as a rate per block, and so only the period and rate need to be provided to cover all settings, but we'll defer this. 